### PR TITLE
Use FlatStyle.System for Next and Cancel buttons

### DIFF
--- a/src/Library/WizardControl.cs
+++ b/src/Library/WizardControl.cs
@@ -53,6 +53,8 @@ namespace AeroWizard
 		public WizardControl()
 		{
 			InitializeComponent();
+			nextButton.FlatStyle = FlatStyle.System;
+			cancelButton.FlatStyle = FlatStyle.System;
 
 			OnRightToLeftChanged(EventArgs.Empty);
 


### PR DESCRIPTION
Does what the title says, mostly.

This change enables Windows to render the button animations (mouse-over/out, and enable/disable). Using the default FlatStyle.Standard bypasses this feature. Note that this change will disable the display of custom bitmaps on these two buttons; that is an unavoidable issue with Windows Forms. However, I don't think that is a supported scenario for this library anyway. This change does _not_ interfere with the display of the elevation shield icon, as that is drawn by Windows.